### PR TITLE
enable mounting of che source code to container

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -11,3 +11,4 @@ components:
     type: dockerimage
     image: 'quay.io/akesterton/compliance-dev:latest'
     memoryLimit: 1Gi
+    mountSources: true


### PR DESCRIPTION
Issue - the source code was not mounted into the tooling container when che started up

Fix - set the mountSouce to true so the container mounts the source code

Now when someone uses the "automated-governance-terminal-tooling" container in the editor, they can so this who demo from che