### PR TITLE
Deleted note about not copy pasting login command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can use [OpenShift Local](https://developers.redhat.com/products/openshift-l
   oc login --token=sha256~12dHbGNWjMhnuJ7-qhx9tAMnjrJaRpfdswo2HoXUy8_0 --server=https://api.ci-ln-1ldd90k-72292.aws.dev.cloud.com:6443
   ```
 
-  - Copy the full `oc login --token= ...` command from your web browser, and paste it into your termainal. Invoke the command in your terminal and follow the directions.  DO NOT COPY AND PASTE THE SAMPLE OC LOGIN COMMAND, IT WILL NOT WORK.
+  - Copy the full `oc login --token= ...` command from your web browser, and paste it into your termainal. Invoke the command in your terminal and follow the directions.
   - Validate you're logged in by invoking the commaned `oc status`.  The terminal will output information. The first line will say `In project default on server ...`.  
   - You are succesfully logged in if the response has the exact server used in the oc login command.
 


### PR DESCRIPTION
@BillBensing We tell them to copy paste a login command, and the next sentence is "do not paste the login command". Is there another login command that gets displayed on some versions of openshift or something? I don't see one in the browser or on the command line.